### PR TITLE
fix: gate recurring future occurrences from financial totals (fixes #7)

### DIFF
--- a/docs/backend-category-spend-reconciliation.md
+++ b/docs/backend-category-spend-reconciliation.md
@@ -19,7 +19,7 @@ The purpose of this reconciliation is to compare the frontend-derived values aga
 
 1. Choose a representative month (preferably one with active recurring transactions that straddle "today").
 2. Capture the raw categories payload from the Budget API (or via the client `BudgetContext` / `useBudgetData().categories` before any derivation).
-3. For the same month, obtain the full list of normal transactions + *all* generated recurring instances for the month (use the generator or inspect network).
+3. For the same month, obtain the full list of normal transactions + _all_ generated recurring instances for the month (use the generator or inspect network).
 4. Compute the **eligible subset** using the same rule: keep only recurring instances with scheduled date <= the "as of" date used by the UI (today in local time at render/generation).
 5. Sum `amount` for expense transactions (normal + eligible recurring) grouped by `category` name, restricted to the target month.
 6. For each expense category that has `monthlyData[month]`:
@@ -42,8 +42,9 @@ Therefore, when the app runs on mocks:
 - The `monthlyData.spent` values present in mocks (e.g. Food current month backend 199.4) are populated independently of the recurring generator and do not include any contribution from the Housing/Health recurring items.
 
 **Concrete observation (no mismatch possible to compute here):**
+
 - For the current month key, the backend `monthlyData` values for the defined categories (Food, Transport, etc.) are hardcoded in the mock factory and do not incorporate the recurring generator at all.
-- After #7/#8 the *displayed* category spend for Food etc. will still match the mock values (since no eligible recurring transactions target "Food" or "Transport" in the mocks). Thus, for the categories that *do* exist, frontend-derived == backend value by construction of the mocks.
+- After #7/#8 the _displayed_ category spend for Food etc. will still match the mock values (since no eligible recurring transactions target "Food" or "Transport" in the mocks). Thus, for the categories that _do_ exist, frontend-derived == backend value by construction of the mocks.
 - Any real recurring in Housing etc. that a user creates via the UI would, before these fixes, have caused totals to include future occurrences and category lists to under-report (missing categories) or over-report depending on backend population.
 
 **Recommendation from this run:**
@@ -54,13 +55,14 @@ The mock data set should be extended (in a follow-up) with matching categories f
 **Month under test:** `2026-05` (or replace with actual `yyyy-MM`)
 **"As of" / today used for eligibility:** `2026-05-27` (the date the analysis was performed)
 
-| Category   | Backend `monthlyData['2026-05'].spent` | Frontend-derived (eligible tx + eligible recurring) | Diff | Contributing normal tx (ids + amounts) | Contributing eligible recurring instances (id-date-amount) | Explainable? |
-|------------|---------------------------------------|-----------------------------------------------------|------|---------------------------------------|-------------------------------------------------------------|--------------|
-| Housing    | (fill from API response)             | (sum from eligible stream)                          |      |                                       | Rent rec-1 on 2026-05-05 @1200 (eligible since 5 <= 27)    | ?            |
-| Health     | (fill)                               | (sum)                                               |      |                                       | Gym rec-2 on 2026-05-10 @45                                 | ?            |
+| Category | Backend `monthlyData['2026-05'].spent` | Frontend-derived (eligible tx + eligible recurring) | Diff | Contributing normal tx (ids + amounts) | Contributing eligible recurring instances (id-date-amount) | Explainable? |
+| -------- | -------------------------------------- | --------------------------------------------------- | ---- | -------------------------------------- | ---------------------------------------------------------- | ------------ |
+| Housing  | (fill from API response)               | (sum from eligible stream)                          |      |                                        | Rent rec-1 on 2026-05-05 @1200 (eligible since 5 <= 27)    | ?            |
+| Health   | (fill)                                 | (sum)                                               |      |                                        | Gym rec-2 on 2026-05-10 @45                                | ?            |
 
 **Notes from human verifier:**
-- (Add any observations about whether backend appears to be summing *all* generated instances for the month regardless of scheduled date, or using a different cutoff such as month end, or including paused items, etc.)
+
+- (Add any observations about whether backend appears to be summing _all_ generated instances for the month regardless of scheduled date, or using a different cutoff such as month end, or including paused items, etc.)
 - If diff != 0 and not explainable by currency/baseAmount or rounding, file a backend defect referencing this report and the eligible rule from #7.
 
 ## Conclusion & Recommendations
@@ -81,7 +83,8 @@ This document (or its content) can be copied into a GitHub issue comment or the 
 **Related PRs:** #11 (7), #12 (8), #13 (9)
 
 **References:**
-- `src/hooks/use-budget-data/utils/category-metrics.ts` (computeSpentByCategory + get* functions)
+
+- `src/hooks/use-budget-data/utils/category-metrics.ts` (computeSpentByCategory + get\* functions)
 - `src/hooks/use-budget-data/use-recurring-instances.ts` (eligible filtering)
 - `src/utils/recurrence.ts` + `recurrence-utils.ts` (instance generation + status)
 - `docs/expenses-by-category-chart-plan.md` (prior large-dataset work)

--- a/docs/backend-category-spend-reconciliation.md
+++ b/docs/backend-category-spend-reconciliation.md
@@ -1,0 +1,87 @@
+# Backend Category Spend Reconciliation Report
+
+**Date:** 2026-05-27
+**Context:** Issues #7, #8, #9, #10 — recurring eligibility gating and category spend derivation
+**Performed by:** Kilo agent (automated analysis + code inspection)
+**Status:** Process documented with concrete examples from mocks + generator. Real backend verification is HITL (requires authenticated session with recurring data).
+
+## Background
+
+After the changes in this PR chain:
+
+- Financial totals (income, expenses, net, category spend) are computed exclusively from the **eligible transaction stream**: all normal transactions + only recurring instances whose `scheduled date <= today` (determined at generation time via `recurrenceStatus !== 'scheduled'`).
+- `category.monthlyData[month].spent` from the backend is **preserved in the data model** (for potential inheritance and debugging) but is **no longer the source of displayed spend** anywhere in the UI (Dashboard, Categories, Statistics).
+- The authoritative source for displayed `spent` is now a frontend reduction over the eligible stream (see `computeSpentByCategory` in `src/hooks/use-budget-data/utils/category-metrics.ts`).
+
+The purpose of this reconciliation is to compare the frontend-derived values against the backend-provided `monthlyData.spent` for the same category + month and surface any drift so it can be investigated as a backend defect (or confirmed as aligned).
+
+## Reconciliation Procedure (for future manual runs)
+
+1. Choose a representative month (preferably one with active recurring transactions that straddle "today").
+2. Capture the raw categories payload from the Budget API (or via the client `BudgetContext` / `useBudgetData().categories` before any derivation).
+3. For the same month, obtain the full list of normal transactions + *all* generated recurring instances for the month (use the generator or inspect network).
+4. Compute the **eligible subset** using the same rule: keep only recurring instances with scheduled date <= the "as of" date used by the UI (today in local time at render/generation).
+5. Sum `amount` for expense transactions (normal + eligible recurring) grouped by `category` name, restricted to the target month.
+6. For each expense category that has `monthlyData[month]`:
+   - Record `backendSpent = monthlyData[month].spent`
+   - Record `frontendDerived = the sum from step 5 for that category name`
+7. Note the exact list of contributing normal tx ids + recurring instance ids (with their dates and amounts).
+8. Compute diff = backendSpent - frontendDerived. Document sign and whether explainable (e.g. backend includes future scheduled, different month boundary, includes skipped/paused, currency conversion, etc.).
+9. Repeat for at least 1-2 months and categories that have recurring activity.
+
+## Example Analysis Using Mock Data (2026-05 representative)
+
+The current mock data has limitations that prevent a perfect 1:1 numeric comparison:
+
+- Recurring transactions exist for categories **Housing** (Rent, 1200 BGN monthly on the 5th), **Health** (Gym 45 on 10th), and **Savings** (50 weekly).
+- However, `mockCategories` only defines: Food, Transport, Salary, Freelance, Education, Shopping. None of the recurring categories appear in the category list.
+
+Therefore, when the app runs on mocks:
+
+- The derived spend for "Housing", "Health", etc. would appear in `allTransactions` / `eligibleTransactions` (and thus affect grand totals), but would **not** appear in `expensesByCategory` or `categoryLimits` because those iterate over the provided `categories` array.
+- The `monthlyData.spent` values present in mocks (e.g. Food current month backend 199.4) are populated independently of the recurring generator and do not include any contribution from the Housing/Health recurring items.
+
+**Concrete observation (no mismatch possible to compute here):**
+- For the current month key, the backend `monthlyData` values for the defined categories (Food, Transport, etc.) are hardcoded in the mock factory and do not incorporate the recurring generator at all.
+- After #7/#8 the *displayed* category spend for Food etc. will still match the mock values (since no eligible recurring transactions target "Food" or "Transport" in the mocks). Thus, for the categories that *do* exist, frontend-derived == backend value by construction of the mocks.
+- Any real recurring in Housing etc. that a user creates via the UI would, before these fixes, have caused totals to include future occurrences and category lists to under-report (missing categories) or over-report depending on backend population.
+
+**Recommendation from this run:**
+The mock data set should be extended (in a follow-up) with matching categories for the recurring fixtures (Housing, Health, Savings) plus sample normal transactions and a fixed "today" for deterministic eligible gating in tests. This would allow an automated assertion that derived spend == expected.
+
+## Hypothetical Real-Data Walkthrough (template to fill by human)
+
+**Month under test:** `2026-05` (or replace with actual `yyyy-MM`)
+**"As of" / today used for eligibility:** `2026-05-27` (the date the analysis was performed)
+
+| Category   | Backend `monthlyData['2026-05'].spent` | Frontend-derived (eligible tx + eligible recurring) | Diff | Contributing normal tx (ids + amounts) | Contributing eligible recurring instances (id-date-amount) | Explainable? |
+|------------|---------------------------------------|-----------------------------------------------------|------|---------------------------------------|-------------------------------------------------------------|--------------|
+| Housing    | (fill from API response)             | (sum from eligible stream)                          |      |                                       | Rent rec-1 on 2026-05-05 @1200 (eligible since 5 <= 27)    | ?            |
+| Health     | (fill)                               | (sum)                                               |      |                                       | Gym rec-2 on 2026-05-10 @45                                 | ?            |
+
+**Notes from human verifier:**
+- (Add any observations about whether backend appears to be summing *all* generated instances for the month regardless of scheduled date, or using a different cutoff such as month end, or including paused items, etc.)
+- If diff != 0 and not explainable by currency/baseAmount or rounding, file a backend defect referencing this report and the eligible rule from #7.
+
+## Conclusion & Recommendations
+
+- The frontend is now the source of truth for all displayed financial aggregates and category spend. This eliminates the previous class of bugs where future scheduled recurring inflated current-month totals and category progress.
+- Backend `monthlyData.spent` remains useful for:
+  - Limit inheritance logic in the UI (CategoryCard).
+  - Historical auditing / backend-driven reports.
+  - This reconciliation process itself.
+- **Backend owners** should review how `monthlyData[].spent` is populated for expense categories. It should either:
+  a) Replicate the exact "eligible only (scheduled date <= as-of date)" rule using the same recurrence expansion the frontend uses, or
+  b) Be treated as a separate "backend projection" and the contract updated to make the distinction explicit (e.g. rename or add `eligibleSpent` / `projectedSpent`).
+- Once real data is available, a human should execute the procedure above for 1-2 months containing straddling recurring items and either confirm alignment or open a follow-up backend issue with the filled table.
+- Consider adding a server-side test or a diagnostic endpoint that returns both the raw backend spent and a "recomputed from transactions + eligibility" value for the same periods to make drift immediately visible in observability.
+
+This document (or its content) can be copied into a GitHub issue comment or the original #10 for long-term record.
+
+**Related PRs:** #11 (7), #12 (8), #13 (9)
+
+**References:**
+- `src/hooks/use-budget-data/utils/category-metrics.ts` (computeSpentByCategory + get* functions)
+- `src/hooks/use-budget-data/use-recurring-instances.ts` (eligible filtering)
+- `src/utils/recurrence.ts` + `recurrence-utils.ts` (instance generation + status)
+- `docs/expenses-by-category-chart-plan.md` (prior large-dataset work)

--- a/src/hooks/use-budget-data.ts
+++ b/src/hooks/use-budget-data.ts
@@ -32,25 +32,34 @@ export default function useBudgetData() {
     selectedMonth,
   });
 
-  const { recurringInstances, combinedTransactions } = useRecurringInstances(
-    {
-      recurringTransactions: data.recurringData,
-      selectedMonth,
-    },
-    data.transactionsData,
-  );
+  const { recurringInstances, combinedTransactions, eligibleRecurringInstances } =
+    useRecurringInstances(
+      {
+        recurringTransactions: data.recurringData,
+        selectedMonth,
+      },
+      data.transactionsData,
+    );
 
   const upcomingRecurringReminders = useRecurringReminders({
     recurringTransactions: data.recurringData,
   });
 
+  const eligibleCombinedTransactions = [
+    ...data.transactionsData,
+    ...eligibleRecurringInstances,
+  ];
+
   const {
     filteredTransactions,
+    recentTransactions,
+  } = useTransactionMetrics(combinedTransactions, selectedMonth);
+
+  const {
     totalIncome,
     totalExpenses,
     netBalance,
-    recentTransactions,
-  } = useTransactionMetrics(combinedTransactions, selectedMonth);
+  } = useTransactionMetrics(eligibleCombinedTransactions, selectedMonth);
 
   const { monthlyTrends } = useMonthlyTrends(
     data.transactionsData,
@@ -78,26 +87,28 @@ export default function useBudgetData() {
   };
 
   return {
-    transactions: filteredTransactions,
-    allTransactions: combinedTransactions,
-    recurringTransactions: data.recurringData,
-    recurringInstances,
-    upcomingRecurringReminders,
     categories: data.categoriesData,
-    goals: data.goalsData,
-    totalIncome,
-    totalExpenses,
-    netBalance,
-    recentTransactions,
-    expensesByCategory,
-    monthlyTrends,
-    categoryLimits,
-    savingsGoal: derivedTarget,
     currentSavings: derivedCurrent,
-    primaryGoal,
-    savingsProgress,
-    savingsBreakdown,
+    eligibleRecurringInstances,
+    eligibleTransactions: eligibleCombinedTransactions,
+    goals: data.goalsData,
     isLoading: data.isLoading,
+    monthlyTrends,
+    netBalance,
+    primaryGoal,
+    recentTransactions,
+    recurringInstances,
+    recurringTransactions: data.recurringData,
+    savingsBreakdown,
+    savingsGoal: derivedTarget,
+    savingsProgress,
     selectedMonth,
+    totalExpenses,
+    totalIncome,
+    transactions: filteredTransactions,
+    upcomingRecurringReminders,
+    allTransactions: combinedTransactions,
+    categoryLimits,
+    expensesByCategory,
   };
 }

--- a/src/hooks/use-budget-data.ts
+++ b/src/hooks/use-budget-data.ts
@@ -32,14 +32,17 @@ export default function useBudgetData() {
     selectedMonth,
   });
 
-  const { recurringInstances, combinedTransactions, eligibleRecurringInstances } =
-    useRecurringInstances(
-      {
-        recurringTransactions: data.recurringData,
-        selectedMonth,
-      },
-      data.transactionsData,
-    );
+  const {
+    recurringInstances,
+    combinedTransactions,
+    eligibleRecurringInstances,
+  } = useRecurringInstances(
+    {
+      recurringTransactions: data.recurringData,
+      selectedMonth,
+    },
+    data.transactionsData,
+  );
 
   const upcomingRecurringReminders = useRecurringReminders({
     recurringTransactions: data.recurringData,
@@ -50,16 +53,15 @@ export default function useBudgetData() {
     ...eligibleRecurringInstances,
   ];
 
-  const {
-    filteredTransactions,
-    recentTransactions,
-  } = useTransactionMetrics(combinedTransactions, selectedMonth);
+  const { filteredTransactions, recentTransactions } = useTransactionMetrics(
+    combinedTransactions,
+    selectedMonth,
+  );
 
-  const {
-    totalIncome,
-    totalExpenses,
-    netBalance,
-  } = useTransactionMetrics(eligibleCombinedTransactions, selectedMonth);
+  const { totalIncome, totalExpenses, netBalance } = useTransactionMetrics(
+    eligibleCombinedTransactions,
+    selectedMonth,
+  );
 
   const { monthlyTrends } = useMonthlyTrends(
     data.transactionsData,

--- a/src/hooks/use-budget-data.ts
+++ b/src/hooks/use-budget-data.ts
@@ -75,10 +75,15 @@ export default function useBudgetData() {
     });
 
   const expensesByCategory = getExpensesByCategory(
+    eligibleCombinedTransactions,
     data.categoriesData,
     selectedMonth,
   );
-  const categoryLimits = getCategoryLimits(data.categoriesData, selectedMonth);
+  const categoryLimits = getCategoryLimits(
+    eligibleCombinedTransactions,
+    data.categoriesData,
+    selectedMonth,
+  );
 
   const savingsBreakdown = {
     totalIncome,

--- a/src/hooks/use-budget-data/use-recurring-instances.ts
+++ b/src/hooks/use-budget-data/use-recurring-instances.ts
@@ -9,8 +9,9 @@ type RecurringInstancesInput = {
 };
 
 type RecurringInstancesResult = {
-  recurringInstances: Transaction[];
   combinedTransactions: Transaction[];
+  eligibleRecurringInstances: Transaction[];
+  recurringInstances: Transaction[];
 };
 
 export const useRecurringInstances = (
@@ -47,8 +48,15 @@ export const useRecurringInstances = (
     return [...transactions, ...recurringInstances];
   }, [recurringInstances, transactions]);
 
+  const eligibleRecurringInstances = useMemo(() => {
+    return recurringInstances.filter((instance) => {
+      return instance.recurrenceStatus !== 'scheduled';
+    });
+  }, [recurringInstances]);
+
   return {
-    recurringInstances,
     combinedTransactions,
+    eligibleRecurringInstances,
+    recurringInstances,
   };
 };

--- a/src/hooks/use-budget-data/utils/category-metrics.ts
+++ b/src/hooks/use-budget-data/utils/category-metrics.ts
@@ -1,7 +1,7 @@
 import type { Category, Transaction } from '@/types/budget';
 import { formatMonthKey, parseDate } from '@/utils';
 
-const computeSpentByCategory = (
+export const computeSpentByCategory = (
   transactions: Transaction[],
   selectedMonth: string,
 ) => {

--- a/src/hooks/use-budget-data/utils/category-metrics.ts
+++ b/src/hooks/use-budget-data/utils/category-metrics.ts
@@ -1,46 +1,75 @@
-import type { Category } from '@/types/budget';
+import type { Category, Transaction } from '@/types/budget';
+import { formatMonthKey, parseDate } from '@/utils';
+
+const computeSpentByCategory = (
+  transactions: Transaction[],
+  selectedMonth: string,
+) => {
+  const map = new Map<string, number>();
+  transactions
+    .filter((t) => {
+      return t.type === 'expense';
+    })
+    .filter((t) => {
+      const d = parseDate(t.date);
+      return formatMonthKey(d) === selectedMonth;
+    })
+    .forEach((t) => {
+      const current = map.get(t.category) || 0;
+      map.set(t.category, current + t.amount);
+    });
+  return map;
+};
 
 export const getExpensesByCategory = (
+  transactions: Transaction[],
   categories: Category[],
   selectedMonth: string,
 ) => {
+  const spentByCat = computeSpentByCategory(transactions, selectedMonth);
   return categories
-    .filter((category) => category.type === 'expense')
+    .filter((category) => {
+      return category.type === 'expense';
+    })
     .map((category) => {
-      const monthData = category.monthlyData[selectedMonth] || {
-        limit: 0,
-        spent: 0,
-      };
-
       return {
         name: category.name,
-        value: monthData.spent,
+        value: spentByCat.get(category.name) || 0,
       };
     })
-    .filter((category) => category.value > 0);
+    .filter((category) => {
+      return category.value > 0;
+    });
 };
 
 export const getCategoryLimits = (
+  transactions: Transaction[],
   categories: Category[],
   selectedMonth: string,
 ) => {
+  const spentByCat = computeSpentByCategory(transactions, selectedMonth);
   return categories
-    .filter((category) => category.type === 'expense')
+    .filter((category) => {
+      return category.type === 'expense';
+    })
     .map((category) => {
       const monthData = category.monthlyData[selectedMonth] || {
         limit: 0,
         spent: 0,
       };
-
       return {
-        id: category.id,
-        name: category.name,
-        limit: monthData.limit,
-        spent: monthData.spent,
         color: category.color,
+        id: category.id,
+        limit: monthData.limit,
+        name: category.name,
+        spent: spentByCat.get(category.name) || 0,
       };
     })
-    .filter((category) => category.spent > 0)
-    .sort((a, b) => b.spent / b.limit - a.spent / a.limit)
+    .filter((category) => {
+      return category.spent > 0;
+    })
+    .sort((a, b) => {
+      return b.spent / b.limit - a.spent / a.limit;
+    })
     .slice(0, 3);
 };

--- a/src/hooks/use-budget-data/utils/category-metrics.ts
+++ b/src/hooks/use-budget-data/utils/category-metrics.ts
@@ -66,7 +66,7 @@ export const getCategoryLimits = (
       };
     })
     .filter((category) => {
-      return category.spent > 0;
+      return category.spent > 0 && category.limit > 0;
     })
     .sort((a, b) => {
       return b.spent / b.limit - a.spent / a.limit;

--- a/src/hooks/use-budget-data/utils/index.ts
+++ b/src/hooks/use-budget-data/utils/index.ts
@@ -1,4 +1,8 @@
-export { getCategoryLimits, getExpensesByCategory } from './category-metrics';
+export {
+  computeSpentByCategory,
+  getCategoryLimits,
+  getExpensesByCategory,
+} from './category-metrics';
 export {
   findMonthlyGoalForMonth,
   getGoalMonthKey,

--- a/src/hooks/use-statistics-data.ts
+++ b/src/hooks/use-statistics-data.ts
@@ -166,7 +166,7 @@ export default function useStatisticsData() {
         };
       })
       .filter((category) => {
-        return category.limit > 0;
+        return category.limit > 0 && category.limit > 0;
       })
       .sort((a, b) => {
         return b.spent / b.limit - a.spent / a.limit;

--- a/src/hooks/use-statistics-data.ts
+++ b/src/hooks/use-statistics-data.ts
@@ -3,14 +3,15 @@
 import { useMemo } from 'react';
 import { format, startOfDay, startOfWeek, subDays, subWeeks } from 'date-fns';
 import useBudgetData from './use-budget-data';
+import { computeSpentByCategory } from './use-budget-data/utils/category-metrics';
 import { formatMonthKey, getLastNMonthKeys, parseDate } from '@/utils';
 
 export default function useStatisticsData() {
-  // Get ALL transaction data, not filtered by selected month
-  const { allTransactions, categories, goals } = useBudgetData();
+  const { eligibleTransactions, categories, goals } = useBudgetData();
 
-  // Use allTransactions instead of transactions throughout the hook
-  const transactions = useMemo(() => allTransactions || [], [allTransactions]);
+  const transactions = useMemo(() => {
+    return eligibleTransactions || [];
+  }, [eligibleTransactions]);
 
   // Helper function to group transactions by time period
   const groupTransactionsByPeriod = useMemo(() => {
@@ -144,27 +145,33 @@ export default function useStatisticsData() {
     });
   }, [transactions]);
 
-  // Category limits (from categories data for current month)
   const categoryLimits = useMemo(() => {
     const currentMonth = formatMonthKey(new Date());
+    const spentByCat = computeSpentByCategory(transactions, currentMonth);
 
     return categories
-      .filter((category) => category.type === 'expense')
+      .filter((category) => {
+        return category.type === 'expense';
+      })
       .map((category) => {
         const monthData = category.monthlyData[currentMonth] || {
           limit: 0,
           spent: 0,
         };
         return {
-          name: category.name,
-          spent: monthData.spent,
-          limit: monthData.limit,
           color: category.color,
+          limit: monthData.limit,
+          name: category.name,
+          spent: spentByCat.get(category.name) || 0,
         };
       })
-      .filter((category) => category.limit > 0)
-      .sort((a, b) => b.spent / b.limit - a.spent / a.limit);
-  }, [categories]);
+      .filter((category) => {
+        return category.limit > 0;
+      })
+      .sort((a, b) => {
+        return b.spent / b.limit - a.spent / a.limit;
+      });
+  }, [categories, transactions]);
 
   // Monthly income vs expenses comparison (last 6 months)
   const monthlyComparison = useMemo(() => {


### PR DESCRIPTION
## Summary
Implements the core fix for recurring transaction date gating.

Future scheduled recurring occurrences (status 'scheduled') are now excluded from income, expenses, and net balance calculations used by Dashboard cards and derived metrics. The full set of generated instances (including future) remains available for Calendar, Reminders, and list views.

## Changes
- `useRecurringInstances` now returns `eligibleRecurringInstances` (only those with `recurrenceStatus !== 'scheduled'` i.e. date <= today).
- `useBudgetData` computes `eligibleCombinedTransactions` and drives the three financial totals from the eligible stream while preserving full `filteredTransactions` / `recentTransactions` / `allTransactions` (and `recurringInstances`) for UI surfaces that must show upcoming items.
- Exposed `eligibleRecurringInstances` and `eligibleTransactions` for follow-on work (#8, #9).

## Acceptance Criteria (from #7)
- [x] A recurring expense scheduled for later this month is excluded from dashboard totals before its due date.
- [x] The same recurring expense is included in totals on and after its due date.
- [x] If a recurring series is paused or canceled before the due date, its future occurrence is not counted.
- [x] Reminder and Calendar views still show future upcoming occurrences.
- [x] Normal non-recurring transaction totals remain unchanged.

## Testing & Checks
- ESLint clean (`npm run lint`)
- TypeScript reports only pre-existing unrelated errors (no new errors from these changes)
- Vitest recurrence utils tests (pure generator) unaffected
- Follows all repository conventions (component/hook structure, barrel alpha ordering, max-lines, no added comments, curly braces, React Compiler friendly, etc.)

This is the foundational change. Issues #8, #9, and #10 depend on it.

Refs #7