### PR TITLE
fix: derive all category spend from eligible transaction stream (fixes #8)

### DIFF
--- a/docs/backend-category-spend-reconciliation.md
+++ b/docs/backend-category-spend-reconciliation.md
@@ -1,0 +1,87 @@
+# Backend Category Spend Reconciliation Report
+
+**Date:** 2026-05-27
+**Context:** Issues #7, #8, #9, #10 — recurring eligibility gating and category spend derivation
+**Performed by:** Kilo agent (automated analysis + code inspection)
+**Status:** Process documented with concrete examples from mocks + generator. Real backend verification is HITL (requires authenticated session with recurring data).
+
+## Background
+
+After the changes in this PR chain:
+
+- Financial totals (income, expenses, net, category spend) are computed exclusively from the **eligible transaction stream**: all normal transactions + only recurring instances whose `scheduled date <= today` (determined at generation time via `recurrenceStatus !== 'scheduled'`).
+- `category.monthlyData[month].spent` from the backend is **preserved in the data model** (for potential inheritance and debugging) but is **no longer the source of displayed spend** anywhere in the UI (Dashboard, Categories, Statistics).
+- The authoritative source for displayed `spent` is now a frontend reduction over the eligible stream (see `computeSpentByCategory` in `src/hooks/use-budget-data/utils/category-metrics.ts`).
+
+The purpose of this reconciliation is to compare the frontend-derived values against the backend-provided `monthlyData.spent` for the same category + month and surface any drift so it can be investigated as a backend defect (or confirmed as aligned).
+
+## Reconciliation Procedure (for future manual runs)
+
+1. Choose a representative month (preferably one with active recurring transactions that straddle "today").
+2. Capture the raw categories payload from the Budget API (or via the client `BudgetContext` / `useBudgetData().categories` before any derivation).
+3. For the same month, obtain the full list of normal transactions + *all* generated recurring instances for the month (use the generator or inspect network).
+4. Compute the **eligible subset** using the same rule: keep only recurring instances with scheduled date <= the "as of" date used by the UI (today in local time at render/generation).
+5. Sum `amount` for expense transactions (normal + eligible recurring) grouped by `category` name, restricted to the target month.
+6. For each expense category that has `monthlyData[month]`:
+   - Record `backendSpent = monthlyData[month].spent`
+   - Record `frontendDerived = the sum from step 5 for that category name`
+7. Note the exact list of contributing normal tx ids + recurring instance ids (with their dates and amounts).
+8. Compute diff = backendSpent - frontendDerived. Document sign and whether explainable (e.g. backend includes future scheduled, different month boundary, includes skipped/paused, currency conversion, etc.).
+9. Repeat for at least 1-2 months and categories that have recurring activity.
+
+## Example Analysis Using Mock Data (2026-05 representative)
+
+The current mock data has limitations that prevent a perfect 1:1 numeric comparison:
+
+- Recurring transactions exist for categories **Housing** (Rent, 1200 BGN monthly on the 5th), **Health** (Gym 45 on 10th), and **Savings** (50 weekly).
+- However, `mockCategories` only defines: Food, Transport, Salary, Freelance, Education, Shopping. None of the recurring categories appear in the category list.
+
+Therefore, when the app runs on mocks:
+
+- The derived spend for "Housing", "Health", etc. would appear in `allTransactions` / `eligibleTransactions` (and thus affect grand totals), but would **not** appear in `expensesByCategory` or `categoryLimits` because those iterate over the provided `categories` array.
+- The `monthlyData.spent` values present in mocks (e.g. Food current month backend 199.4) are populated independently of the recurring generator and do not include any contribution from the Housing/Health recurring items.
+
+**Concrete observation (no mismatch possible to compute here):**
+- For the current month key, the backend `monthlyData` values for the defined categories (Food, Transport, etc.) are hardcoded in the mock factory and do not incorporate the recurring generator at all.
+- After #7/#8 the *displayed* category spend for Food etc. will still match the mock values (since no eligible recurring transactions target "Food" or "Transport" in the mocks). Thus, for the categories that *do* exist, frontend-derived == backend value by construction of the mocks.
+- Any real recurring in Housing etc. that a user creates via the UI would, before these fixes, have caused totals to include future occurrences and category lists to under-report (missing categories) or over-report depending on backend population.
+
+**Recommendation from this run:**
+The mock data set should be extended (in a follow-up) with matching categories for the recurring fixtures (Housing, Health, Savings) plus sample normal transactions and a fixed "today" for deterministic eligible gating in tests. This would allow an automated assertion that derived spend == expected.
+
+## Hypothetical Real-Data Walkthrough (template to fill by human)
+
+**Month under test:** `2026-05` (or replace with actual `yyyy-MM`)
+**"As of" / today used for eligibility:** `2026-05-27` (the date the analysis was performed)
+
+| Category   | Backend `monthlyData['2026-05'].spent` | Frontend-derived (eligible tx + eligible recurring) | Diff | Contributing normal tx (ids + amounts) | Contributing eligible recurring instances (id-date-amount) | Explainable? |
+|------------|---------------------------------------|-----------------------------------------------------|------|---------------------------------------|-------------------------------------------------------------|--------------|
+| Housing    | (fill from API response)             | (sum from eligible stream)                          |      |                                       | Rent rec-1 on 2026-05-05 @1200 (eligible since 5 <= 27)    | ?            |
+| Health     | (fill)                               | (sum)                                               |      |                                       | Gym rec-2 on 2026-05-10 @45                                 | ?            |
+
+**Notes from human verifier:**
+- (Add any observations about whether backend appears to be summing *all* generated instances for the month regardless of scheduled date, or using a different cutoff such as month end, or including paused items, etc.)
+- If diff != 0 and not explainable by currency/baseAmount or rounding, file a backend defect referencing this report and the eligible rule from #7.
+
+## Conclusion & Recommendations
+
+- The frontend is now the source of truth for all displayed financial aggregates and category spend. This eliminates the previous class of bugs where future scheduled recurring inflated current-month totals and category progress.
+- Backend `monthlyData.spent` remains useful for:
+  - Limit inheritance logic in the UI (CategoryCard).
+  - Historical auditing / backend-driven reports.
+  - This reconciliation process itself.
+- **Backend owners** should review how `monthlyData[].spent` is populated for expense categories. It should either:
+  a) Replicate the exact "eligible only (scheduled date <= as-of date)" rule using the same recurrence expansion the frontend uses, or
+  b) Be treated as a separate "backend projection" and the contract updated to make the distinction explicit (e.g. rename or add `eligibleSpent` / `projectedSpent`).
+- Once real data is available, a human should execute the procedure above for 1-2 months containing straddling recurring items and either confirm alignment or open a follow-up backend issue with the filled table.
+- Consider adding a server-side test or a diagnostic endpoint that returns both the raw backend spent and a "recomputed from transactions + eligibility" value for the same periods to make drift immediately visible in observability.
+
+This document (or its content) can be copied into a GitHub issue comment or the original #10 for long-term record.
+
+**Related PRs:** #11 (7), #12 (8), #13 (9)
+
+**References:**
+- `src/hooks/use-budget-data/utils/category-metrics.ts` (computeSpentByCategory + get* functions)
+- `src/hooks/use-budget-data/use-recurring-instances.ts` (eligible filtering)
+- `src/utils/recurrence.ts` + `recurrence-utils.ts` (instance generation + status)
+- `docs/expenses-by-category-chart-plan.md` (prior large-dataset work)

--- a/src/hooks/use-budget-data.ts
+++ b/src/hooks/use-budget-data.ts
@@ -75,10 +75,15 @@ export default function useBudgetData() {
     });
 
   const expensesByCategory = getExpensesByCategory(
+    eligibleCombinedTransactions,
     data.categoriesData,
     selectedMonth,
   );
-  const categoryLimits = getCategoryLimits(data.categoriesData, selectedMonth);
+  const categoryLimits = getCategoryLimits(
+    eligibleCombinedTransactions,
+    data.categoriesData,
+    selectedMonth,
+  );
 
   const savingsBreakdown = {
     totalIncome,

--- a/src/hooks/use-budget-data/utils/category-metrics.ts
+++ b/src/hooks/use-budget-data/utils/category-metrics.ts
@@ -1,7 +1,7 @@
 import type { Category, Transaction } from '@/types/budget';
 import { formatMonthKey, parseDate } from '@/utils';
 
-const computeSpentByCategory = (
+export const computeSpentByCategory = (
   transactions: Transaction[],
   selectedMonth: string,
 ) => {

--- a/src/hooks/use-budget-data/utils/category-metrics.ts
+++ b/src/hooks/use-budget-data/utils/category-metrics.ts
@@ -1,46 +1,75 @@
-import type { Category } from '@/types/budget';
+import type { Category, Transaction } from '@/types/budget';
+import { formatMonthKey, parseDate } from '@/utils';
+
+const computeSpentByCategory = (
+  transactions: Transaction[],
+  selectedMonth: string,
+) => {
+  const map = new Map<string, number>();
+  transactions
+    .filter((t) => {
+      return t.type === 'expense';
+    })
+    .filter((t) => {
+      const d = parseDate(t.date);
+      return formatMonthKey(d) === selectedMonth;
+    })
+    .forEach((t) => {
+      const current = map.get(t.category) || 0;
+      map.set(t.category, current + t.amount);
+    });
+  return map;
+};
 
 export const getExpensesByCategory = (
+  transactions: Transaction[],
   categories: Category[],
   selectedMonth: string,
 ) => {
+  const spentByCat = computeSpentByCategory(transactions, selectedMonth);
   return categories
-    .filter((category) => category.type === 'expense')
+    .filter((category) => {
+      return category.type === 'expense';
+    })
     .map((category) => {
-      const monthData = category.monthlyData[selectedMonth] || {
-        limit: 0,
-        spent: 0,
-      };
-
       return {
         name: category.name,
-        value: monthData.spent,
+        value: spentByCat.get(category.name) || 0,
       };
     })
-    .filter((category) => category.value > 0);
+    .filter((category) => {
+      return category.value > 0;
+    });
 };
 
 export const getCategoryLimits = (
+  transactions: Transaction[],
   categories: Category[],
   selectedMonth: string,
 ) => {
+  const spentByCat = computeSpentByCategory(transactions, selectedMonth);
   return categories
-    .filter((category) => category.type === 'expense')
+    .filter((category) => {
+      return category.type === 'expense';
+    })
     .map((category) => {
       const monthData = category.monthlyData[selectedMonth] || {
         limit: 0,
         spent: 0,
       };
-
       return {
-        id: category.id,
-        name: category.name,
-        limit: monthData.limit,
-        spent: monthData.spent,
         color: category.color,
+        id: category.id,
+        limit: monthData.limit,
+        name: category.name,
+        spent: spentByCat.get(category.name) || 0,
       };
     })
-    .filter((category) => category.spent > 0)
-    .sort((a, b) => b.spent / b.limit - a.spent / a.limit)
+    .filter((category) => {
+      return category.spent > 0;
+    })
+    .sort((a, b) => {
+      return b.spent / b.limit - a.spent / a.limit;
+    })
     .slice(0, 3);
 };

--- a/src/hooks/use-budget-data/utils/index.ts
+++ b/src/hooks/use-budget-data/utils/index.ts
@@ -1,4 +1,8 @@
-export { getCategoryLimits, getExpensesByCategory } from './category-metrics';
+export {
+  computeSpentByCategory,
+  getCategoryLimits,
+  getExpensesByCategory,
+} from './category-metrics';
 export {
   findMonthlyGoalForMonth,
   getGoalMonthKey,

--- a/src/hooks/use-statistics-data.ts
+++ b/src/hooks/use-statistics-data.ts
@@ -3,14 +3,15 @@
 import { useMemo } from 'react';
 import { format, startOfDay, startOfWeek, subDays, subWeeks } from 'date-fns';
 import useBudgetData from './use-budget-data';
+import { computeSpentByCategory } from './use-budget-data/utils/category-metrics';
 import { formatMonthKey, getLastNMonthKeys, parseDate } from '@/utils';
 
 export default function useStatisticsData() {
-  // Get ALL transaction data, not filtered by selected month
-  const { allTransactions, categories, goals } = useBudgetData();
+  const { eligibleTransactions, categories, goals } = useBudgetData();
 
-  // Use allTransactions instead of transactions throughout the hook
-  const transactions = useMemo(() => allTransactions || [], [allTransactions]);
+  const transactions = useMemo(() => {
+    return eligibleTransactions || [];
+  }, [eligibleTransactions]);
 
   // Helper function to group transactions by time period
   const groupTransactionsByPeriod = useMemo(() => {
@@ -144,27 +145,33 @@ export default function useStatisticsData() {
     });
   }, [transactions]);
 
-  // Category limits (from categories data for current month)
   const categoryLimits = useMemo(() => {
     const currentMonth = formatMonthKey(new Date());
+    const spentByCat = computeSpentByCategory(transactions, currentMonth);
 
     return categories
-      .filter((category) => category.type === 'expense')
+      .filter((category) => {
+        return category.type === 'expense';
+      })
       .map((category) => {
         const monthData = category.monthlyData[currentMonth] || {
           limit: 0,
           spent: 0,
         };
         return {
-          name: category.name,
-          spent: monthData.spent,
-          limit: monthData.limit,
           color: category.color,
+          limit: monthData.limit,
+          name: category.name,
+          spent: spentByCat.get(category.name) || 0,
         };
       })
-      .filter((category) => category.limit > 0)
-      .sort((a, b) => b.spent / b.limit - a.spent / a.limit);
-  }, [categories]);
+      .filter((category) => {
+        return category.limit > 0;
+      })
+      .sort((a, b) => {
+        return b.spent / b.limit - a.spent / a.limit;
+      });
+  }, [categories, transactions]);
 
   // Monthly income vs expenses comparison (last 6 months)
   const monthlyComparison = useMemo(() => {


### PR DESCRIPTION
## Summary
Replaces reliance on `category.monthlyData[month].spent` (backend-provided) with a frontend-derived total computed from the **eligible** transaction stream (normal transactions + only recurring occurrences whose scheduled date <= today). This ensures Dashboard category widgets, Category cards/lists, and spend numbers are consistent with the corrected totals from #7.

## Key Implementation
- New internal `computeSpentByCategory` helper in `category-metrics.ts` aggregates `amount` from the provided transactions filtered by type=expense + month.
- `getExpensesByCategory` and `getCategoryLimits` signatures updated to accept the transactions list first (for derivation), then categories (for metadata: name/color/limit).
- Backend `monthlyData.spent` is read only for legacy limit inheritance in CategoryCard; the *displayed* `spent` now always comes from the eligible stream.
- Call site in `useBudgetData` updated to forward `eligibleCombinedTransactions`.

## Acceptance Criteria (from #8)
- [x] Categories page spend matches the eligible transaction stream for the same month.
- [x] Dashboard category widgets (summary, chart, limits) match the same spend values.
- [x] Backend metadata (name, color, limit) is preserved in all views.
- [x] Backend `monthlyData.spent` is not used for displayed spend in analytics views.
- [x] A recurring expense that is not yet eligible is excluded from category spend.

## Stacking & Dependencies
This PR is based on `fix/7-recurring-date-gating` (the foundational eligible stream). It will be ready for review/merge after #7 lands in the base.

Refs #8